### PR TITLE
JSON returns any

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -80,7 +80,8 @@ export class TransportClient implements Client {
     return res.value;
   }
 
-  async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<object> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
     if (!ctx) {
       ctx = new ClientContext();
     }

--- a/src/fixtures/contents.ts
+++ b/src/fixtures/contents.ts
@@ -28,10 +28,15 @@ export function protoAny() {
     return Any.pack(protoVal);
 }
 
+export type jsonConfigType = {
+    a: number;
+}
+
 export function testContents() {
-    const jsonVal = Value.fromJsonString(JSON.stringify({
+    const json: jsonConfigType = {
         a: 1
-    }));
+    };
+    const jsonVal = Value.fromJsonString(JSON.stringify(json));
     const pAny = protoAny();
     return contents(
         'sha', 

--- a/src/memory/__tests__/backend.test.ts
+++ b/src/memory/__tests__/backend.test.ts
@@ -1,6 +1,6 @@
 import { DeregisterClientResponse, GetRepositoryVersionResponse, RegisterClientResponse, SendFlagEvaluationMetricsRequest, SendFlagEvaluationMetricsResponse } from "@buf/lekkodev_cli.bufbuild_es/lekko/backend/v1beta1/distribution_service_pb";
 import { ClientContext } from "../../context/context";
-import { protoAny, testContents } from '../../fixtures/contents';
+import { jsonConfigType, protoAny, testContents } from '../../fixtures/contents';
 import { ClientTransportBuilder, TransportProtocol } from "../../transport-builder";
 import { Backend } from "../backend";
 
@@ -147,3 +147,20 @@ test('send metrics batch size', async () => {
     expect(backend.eventsBatcher.batch.length).toEqual(0);
 });
 
+test('test json return type', async () => {
+    const testBackend = await setupBackend();
+    const backend = testBackend.backend;
+
+    const mockSendEvents = jest.fn();
+    Object.defineProperty(backend.distClient, "sendFlagEvaluationMetrics", { value: mockSendEvents });
+    jest.spyOn(backend.distClient, "sendFlagEvaluationMetrics").mockImplementation(async () => {
+        return new SendFlagEvaluationMetricsResponse();
+    });
+
+    await backend.initialize();
+
+    const result: jsonConfigType = await backend.getJSONFeature('ns-1', 'json', new ClientContext());
+    expect(result).toEqual({a: 1});
+
+    await backend.close();
+});

--- a/src/memory/backend.ts
+++ b/src/memory/backend.ts
@@ -65,7 +65,8 @@ export class Backend implements Client {
         await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
         return wrapper.value;
     }
-    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<object> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
         const wrapper = new Value();
         await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
         return JSON.parse(wrapper.toJsonString());

--- a/src/memory/events.ts
+++ b/src/memory/events.ts
@@ -60,6 +60,7 @@ export class EventsBatcher {
                 sessionKey: this.sessionKey
             })), this.backoffOptions);
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.log(`failed to send metrics batch: ${e}`);
             this.batch.unshift(...events);
         }

--- a/src/memory/git.ts
+++ b/src/memory/git.ts
@@ -102,7 +102,8 @@ export class Git implements Client {
         await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
         return wrapper.value;
     }
-    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<object> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
         const wrapper = new Value();
         await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
         return JSON.parse(wrapper.toJsonString());

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -27,6 +27,7 @@ export class SDKServer {
         if (this.server) {
             this.server.close((err) => {
                 if (err) {
+                    // eslint-disable-next-line no-console
                     console.error('Error closing sdk server', err);
                 }
             });

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -6,7 +6,8 @@ export interface Client {
     getIntFeature(namespace: string, key: string, ctx: ClientContext): Promise<bigint>;
     getFloatFeature(namespace: string, key: string, ctx: ClientContext): Promise<number>;
     getStringFeature(namespace: string, key: string, ctx: ClientContext): Promise<string>
-    getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<object>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any>;
     getProtoFeature(namespace: string, key: string, ctx: ClientContext): Promise<Any>;
     close(): Promise<void>;
 }


### PR DESCRIPTION
Switches `getJSONValue` to return `any` instead of `object`. While explicit `any` is discouraged, it follows the type signature of `JSON.parse` [[relevant](https://github.com/microsoft/TypeScript/issues/26993#issuecomment-419956424)], which is what we're calling under the hood. 

Lekko allows users to store either `object` or `Array` types in a json config. Therefore `object` is too restrictive. It also prevents callers from doing the following, which throws a compile time ts error:

```javascript
type config = {
    key: string
}

const result: config = await client.getJSONFeature(ns, key, ctx);
```

this is a breaking change. 