### PR TITLE
Allow undefined context

### DIFF
--- a/example-ts/index.ts
+++ b/example-ts/index.ts
@@ -1,12 +1,11 @@
 import { program } from 'commander';
 import {
     Client,
-    ClientContext,
     TransportProtocol,
     initAPIClient,
     initCachedAPIClient,
     initCachedGitClient,
-    initSidecarClient,
+    initSidecarClient
 } from '../';
 
 program
@@ -98,14 +97,13 @@ function transportProtocol() {
 async function getConfig(client: Client) {
     const ns = opts.namespace;
     const key = opts.config;
-    const ctx = new ClientContext();
     switch (opts.configType) {
-        case 'bool': return await client.getBoolFeature(ns, key, ctx);
-        case 'string': return await client.getStringFeature(ns, key, ctx);
-        case 'int': return await client.getIntFeature(ns, key, ctx);
-        case 'float': return await client.getFloatFeature(ns, key, ctx);
-        case 'json': return await client.getJSONFeature(ns, key, ctx);
-        case 'proto': return await client.getProtoFeature(ns, key, ctx);
+        case 'bool': return await client.getBoolFeature(ns, key);
+        case 'string': return await client.getStringFeature(ns, key);
+        case 'int': return await client.getIntFeature(ns, key);
+        case 'float': return await client.getFloatFeature(ns, key);
+        case 'json': return await client.getJSONFeature(ns, key);
+        case 'proto': return await client.getProtoFeature(ns, key);
     }
     throw new Error(`unknown config type '${opts.configType}' `);
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,7 +38,7 @@ export class TransportClient implements Client {
     return;
   }
 
-  async getBoolFeature(namespace: string, key: string, ctx: ClientContext): Promise<boolean> {
+  async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -52,7 +52,7 @@ export class TransportClient implements Client {
     return res.value;
   }
 
-  async getIntFeature(namespace: string, key: string, ctx: ClientContext): Promise<bigint> {
+  async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -66,7 +66,7 @@ export class TransportClient implements Client {
     return res.value;
   }
 
-  async getFloatFeature(namespace: string, key: string, ctx: ClientContext): Promise<number> {
+  async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -81,7 +81,7 @@ export class TransportClient implements Client {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
+  async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -101,7 +101,7 @@ export class TransportClient implements Client {
     return {};
   }
 
-  async getProtoFeature(namespace: string, key: string, ctx: ClientContext): Promise<Any> {
+  async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -123,7 +123,7 @@ export class TransportClient implements Client {
     });
   }
 
-  async getStringFeature(namespace: string, key: string, ctx: ClientContext): Promise<string> {
+  async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
     if (!ctx) {
       ctx = new ClientContext();
     }

--- a/src/evaluation/__tests__/eval.test.ts
+++ b/src/evaluation/__tests__/eval.test.ts
@@ -13,7 +13,7 @@ test('empty config tree', () => {
 
 type testEvalParams = {
     config: Feature,
-    context: ClientContext,
+    context: ClientContext | undefined,
     expected?: number // we are only testing int config traversal
     hasError?: boolean
     expectedPath?: number[]
@@ -49,6 +49,15 @@ describe('no overrides traversal', () => {
     testEval({
         config: config(tree()),
         context: new ClientContext().setString('key', 'anything'),
+        expected: defaultValue,
+        expectedPath: []
+    });
+});
+
+describe('test empty context', () => {
+    testEval({
+        config: config(tree()),
+        context: undefined,
         expected: defaultValue,
         expectedPath: []
     });

--- a/src/evaluation/eval.ts
+++ b/src/evaluation/eval.ts
@@ -14,7 +14,7 @@ export type EvaluationResult = {
 // where the config is represented as a tree. The root of the tree contains a default value, and 
 // each override is a child node of the root. Overrides can also have overrides, which is what
 // makes this an n-level tree traversal algorithm.
-export function evaluate(config: Feature, namespace: string, context: ClientContext) : EvaluationResult {
+export function evaluate(config: Feature, namespace: string, context?: ClientContext) : EvaluationResult {
     if (!config.tree) {
         throw new Error('config tree is empty');
     }
@@ -42,11 +42,11 @@ type traverseResult = {
     path: number[]
 }
 
-function traverse(override: Constraint | undefined, namespace: string, configName: string, context: ClientContext) : traverseResult {
+function traverse(override: Constraint | undefined, namespace: string, configName: string, context?: ClientContext) : traverseResult {
     if (!override) {
         return { passes: false, path: [] };
     }
-    const passes = evaluateRule(override.ruleAstNew, context, namespace, configName);
+    const passes = evaluateRule(override.ruleAstNew, namespace, configName, context);
     if (!passes) {
         // If the rule fails, we avoid further traversal
         return { passes, path: [] };

--- a/src/memory/__tests__/backend.test.ts
+++ b/src/memory/__tests__/backend.test.ts
@@ -164,3 +164,21 @@ test('test json return type', async () => {
 
     await backend.close();
 });
+
+test('test empty context', async () => {
+    const testBackend = await setupBackend();
+    const backend = testBackend.backend;
+
+    const mockSendEvents = jest.fn();
+    Object.defineProperty(backend.distClient, "sendFlagEvaluationMetrics", { value: mockSendEvents });
+    jest.spyOn(backend.distClient, "sendFlagEvaluationMetrics").mockImplementation(async () => {
+        return new SendFlagEvaluationMetricsResponse();
+    });
+
+    await backend.initialize();
+
+    const result = await backend.getBoolFeature('ns-1', 'bool');
+    expect(result).toEqual(true);
+
+    await backend.close();
+});

--- a/src/memory/backend.ts
+++ b/src/memory/backend.ts
@@ -45,52 +45,52 @@ export class Backend implements Client {
         this.server = new SDKServer(this.store, port);
     }
 
-    async getBoolFeature(namespace: string, key: string, ctx: ClientContext): Promise<boolean> {
+    async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
         const wrapper = new BoolValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getIntFeature(namespace: string, key: string, ctx: ClientContext): Promise<bigint> {
+    async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
         const wrapper = new Int64Value();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getFloatFeature(namespace: string, key: string, ctx: ClientContext): Promise<number> {
+    async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
         const wrapper = new DoubleValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getStringFeature(namespace: string, key: string, ctx: ClientContext): Promise<string> {
+    async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
         const wrapper = new StringValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
+    async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
         const wrapper = new Value();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return JSON.parse(wrapper.toJsonString());
     }
-    async getProtoFeature(namespace: string, key: string, ctx: ClientContext): Promise<Any> {
+    async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
         const result = this.store.evaluateType(namespace, key, ctx);
-        this.track(namespace, key, ctx, result);
+        this.track(namespace, key, result, ctx);
         return result.evalResult.value;
     }
 
     async evaluateAndUnpack(
         namespace: string, 
-        configKey: string, 
-        ctx: ClientContext, 
+        configKey: string,  
         wrapper: BoolValue | StringValue | Int64Value | DoubleValue | Value,
+        ctx?: ClientContext,
     ) {
         const result = this.store.evaluateType(namespace, configKey, ctx);
         if (!result.evalResult.value.unpackTo(wrapper)) {
             throw new Error('type mismatch');
         }
-        this.track(namespace, configKey, ctx, result);
+        this.track(namespace, configKey, result, ctx);
     }
 
-    track(namespace: string, key: string, ctx: ClientContext, result: StoredEvalResult) {
+    track(namespace: string, key: string, result: StoredEvalResult, ctx?: ClientContext) {
         if (!this.eventsBatcher) {
             return;
         }

--- a/src/memory/events.ts
+++ b/src/memory/events.ts
@@ -77,8 +77,11 @@ export class EventsBatcher {
     }
 }
 
-export function toContextKeysProto(context: ClientContext) : ContextKey[] {
+export function toContextKeysProto(context?: ClientContext) : ContextKey[] {
     const result: ContextKey[] = [];
+    if (!context) {
+        return result;
+    }
     for (const key in context.data) {
         result.push(new ContextKey({
             key,

--- a/src/memory/git.ts
+++ b/src/memory/git.ts
@@ -82,39 +82,39 @@ export class Git implements Client {
         }
     }
 
-    async getBoolFeature(namespace: string, key: string, ctx: ClientContext): Promise<boolean> {
+    async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
         const wrapper = new BoolValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getIntFeature(namespace: string, key: string, ctx: ClientContext): Promise<bigint> {
+    async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
         const wrapper = new Int64Value();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getFloatFeature(namespace: string, key: string, ctx: ClientContext): Promise<number> {
+    async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
         const wrapper = new DoubleValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getStringFeature(namespace: string, key: string, ctx: ClientContext): Promise<string> {
+    async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
         const wrapper = new StringValue();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any> {
+    async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
         const wrapper = new Value();
-        await this.evaluateAndUnpack(namespace, key, ctx, wrapper);
+        await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return JSON.parse(wrapper.toJsonString());
     }
-    async getProtoFeature(namespace: string, key: string, ctx: ClientContext): Promise<Any> {
+    async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
         const result = this.store.evaluateType(namespace, key, ctx);
-        this.track(namespace, key, ctx, result);
+        this.track(namespace, key, result, ctx);
         return result.evalResult.value;
     }
 
-    track(namespace: string, key: string, ctx: ClientContext, result: StoredEvalResult) {
+    track(namespace: string, key: string, result: StoredEvalResult, ctx?: ClientContext) {
         if (!this.eventsBatcher) {
             return;
         }
@@ -133,14 +133,14 @@ export class Git implements Client {
     async evaluateAndUnpack(
         namespace: string, 
         configKey: string, 
-        ctx: ClientContext, 
         wrapper: BoolValue | StringValue | Int64Value | DoubleValue | Value,
+        ctx?: ClientContext,
     ) {
         const result = this.store.evaluateType(namespace, configKey, ctx);
         if (!result.evalResult.value.unpackTo(wrapper)) {
             throw new Error('type mismatch');
         }
-        this.track(namespace, configKey, ctx, result);
+        this.track(namespace, configKey, result, ctx);
     }
 
     async load() {

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -47,7 +47,7 @@ export class Store {
         return result;
     }
 
-    evaluateType(namespace: string, configKey: string, context: ClientContext) : StoredEvalResult {
+    evaluateType(namespace: string, configKey: string, context?: ClientContext) : StoredEvalResult {
         const cfg = this.get(namespace, configKey);
         return {
             ...cfg,

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -2,13 +2,13 @@ import { Any } from "@bufbuild/protobuf";
 import { ClientContext } from "../context/context";
 
 export interface Client {
-    getBoolFeature(namespace: string, key: string, ctx: ClientContext): Promise<boolean>;
-    getIntFeature(namespace: string, key: string, ctx: ClientContext): Promise<bigint>;
-    getFloatFeature(namespace: string, key: string, ctx: ClientContext): Promise<number>;
-    getStringFeature(namespace: string, key: string, ctx: ClientContext): Promise<string>
+    getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean>;
+    getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint>;
+    getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number>;
+    getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getJSONFeature(namespace: string, key: string, ctx: ClientContext): Promise<any>;
-    getProtoFeature(namespace: string, key: string, ctx: ClientContext): Promise<Any>;
+    getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any>;
+    getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any>;
     close(): Promise<void>;
 }
 


### PR DESCRIPTION
If the caller doesn't want to pass ctx, we should avoid the allocation and allow them to pass in 
an undefined context. This changes the interface for `Client`.
