### PR TITLE
Rename client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ const client = await lekko.initCachedAPIClient({
 });
 
 const context = new lekko.ClientContext().setString("my_context_key", "my_context_value");
-const stringFeature = await client.getStringFeature("my_namespace", "my_feature", context);
-console.log(stringFeature);
+const stringConfig = await client.getString("my_namespace", "my_config", context);
+console.log(stringConfig);
 ```
 
 #### Initializing a cached Lekko client in git mode
@@ -69,8 +69,8 @@ const client = await lekko.initCachedGitClient({
 });
 
 const context = new lekko.ClientContext().setString("my_context_key", "my_context_value");
-const boolFeature = await client.getBoolFeature("default", "example", context);
-console.log(boolFeature);
+const boolConfig = await client.getBool("default", "example", context);
+console.log(boolConfig);
 ```
 
 #### Note on using ES modules

--- a/example-ts/index.ts
+++ b/example-ts/index.ts
@@ -98,12 +98,12 @@ async function getConfig(client: Client) {
     const ns = opts.namespace;
     const key = opts.config;
     switch (opts.configType) {
-        case 'bool': return await client.getBoolFeature(ns, key);
-        case 'string': return await client.getStringFeature(ns, key);
-        case 'int': return await client.getIntFeature(ns, key);
-        case 'float': return await client.getFloatFeature(ns, key);
-        case 'json': return await client.getJSONFeature(ns, key);
-        case 'proto': return await client.getProtoFeature(ns, key);
+        case 'bool': return await client.getBool(ns, key);
+        case 'string': return await client.getString(ns, key);
+        case 'int': return await client.getInt(ns, key);
+        case 'float': return await client.getFloat(ns, key);
+        case 'json': return await client.getJSON(ns, key);
+        case 'proto': return await client.getProto(ns, key);
     }
     throw new Error(`unknown config type '${opts.configType}' `);
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -48,7 +48,7 @@ test('build gRPC client', async () => {
 const SAMPLE_CONTEXT = new ClientContext();
 SAMPLE_CONTEXT.setString('sample_key', 'sample_value');
 
-test('get bool feature', async () => {
+test('get bool config', async () => {
   const client = await initAPIClient({
     apiKey: "apiKey",
     repositoryOwner: "lekkodev",
@@ -63,7 +63,7 @@ test('get bool feature', async () => {
   jest.spyOn(client.client, "getBoolValue").mockImplementation(async () => GetBoolValueResponse.fromJson({
     value: true,
   }));
-  expect(await client.getBoolFeature('types', 'bool', SAMPLE_CONTEXT)).toBe(true);
+  expect(await client.getBool('types', 'bool', SAMPLE_CONTEXT)).toBe(true);
   expect(mockFn.mock.lastCall[0]).toEqual(GetBoolValueRequest.fromJson({
     key: 'bool',
     context: {
@@ -79,7 +79,7 @@ test('get bool feature', async () => {
   }));
 });
 
-test('get int feature', async () => {
+test('get int config', async () => {
   const client = await initAPIClient({
     apiKey: "apiKey",
     repositoryOwner: "lekkodev",
@@ -94,7 +94,7 @@ test('get int feature', async () => {
   jest.spyOn(client.client, "getIntValue").mockImplementation(async () => new GetIntValueResponse({
     value: BigInt(42),
   }));
-  expect(await client.getIntFeature('types', 'int', SAMPLE_CONTEXT)).toEqual(BigInt(42));
+  expect(await client.getInt('types', 'int', SAMPLE_CONTEXT)).toEqual(BigInt(42));
   expect(mockFn.mock.lastCall[0]).toEqual(GetIntValueRequest.fromJson({
     key: 'int',
     context: {
@@ -110,7 +110,7 @@ test('get int feature', async () => {
   }));
 });
 
-test('get float feature', async () => {
+test('get float config', async () => {
   const client = await initAPIClient({
     apiKey: "apiKey",
     repositoryOwner: "lekkodev",
@@ -125,7 +125,7 @@ test('get float feature', async () => {
   jest.spyOn(client.client, "getFloatValue").mockImplementation(async () => GetFloatValueResponse.fromJson({
     value: 3.14,
   }));
-  expect(await client.getFloatFeature('types', 'float', SAMPLE_CONTEXT)).toBeCloseTo(3.14);
+  expect(await client.getFloat('types', 'float', SAMPLE_CONTEXT)).toBeCloseTo(3.14);
   expect(mockFn.mock.lastCall[0]).toEqual(GetFloatValueRequest.fromJson({
     key: 'float',
     context: {
@@ -141,7 +141,7 @@ test('get float feature', async () => {
   }));
 });
 
-test('get json feature', async () => {
+test('get json config', async () => {
   const client = await initAPIClient({
     apiKey: "apiKey",
     repositoryOwner: "lekkodev",
@@ -162,7 +162,7 @@ test('get json feature', async () => {
   jest.spyOn(client.client, "getJSONValue").mockImplementation(async () => GetJSONValueResponse.fromJson({
     value: Buffer.from(JSON.stringify(mockedValue)).toString('base64'),
   }));
-  expect(await client.getJSONFeature('types', 'json', SAMPLE_CONTEXT)).toEqual(mockedValue);
+  expect(await client.getJSON('types', 'json', SAMPLE_CONTEXT)).toEqual(mockedValue);
   expect(mockFn.mock.lastCall[0]).toEqual(GetJSONValueRequest.fromJson({
     key: 'json',
     context: {
@@ -178,7 +178,7 @@ test('get json feature', async () => {
   }));
 });
 
-test('get string feature', async () => {
+test('get string config', async () => {
   const client = await initAPIClient({
     apiKey: "apiKey",
     repositoryOwner: "lekkodev",
@@ -193,7 +193,7 @@ test('get string feature', async () => {
   jest.spyOn(client.client, "getStringValue").mockImplementation(async () => GetStringValueResponse.fromJson({
     value: 'foobar',
   }));
-  expect(await client.getStringFeature('types', 'string', SAMPLE_CONTEXT)).toBe('foobar');
+  expect(await client.getString('types', 'string', SAMPLE_CONTEXT)).toBe('foobar');
   expect(mockFn.mock.lastCall[0]).toEqual(GetStringValueRequest.fromJson({
     key: 'string',
     context: {
@@ -209,7 +209,7 @@ test('get string feature', async () => {
   }));
 });
 
-test('get proto feature', async () => {
+test('get proto config', async () => {
   const a = Any.pack(new BoolValue({
     value: true
   }));
@@ -226,7 +226,7 @@ test('get proto feature', async () => {
       writable: true
     });
     jest.spyOn(client.client, "getProtoValue").mockImplementation(async () => resp);
-    expect(await client.getProtoFeature('types', 'proto', SAMPLE_CONTEXT)).toEqual(a);
+    expect(await client.getProto('types', 'proto', SAMPLE_CONTEXT)).toEqual(a);
     expect(mockFn.mock.lastCall[0]).toEqual(GetProtoValueRequest.fromJson({
       key: 'proto',
       context: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,7 +38,7 @@ export class TransportClient implements Client {
     return;
   }
 
-  async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
+  async getBool(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -52,7 +52,7 @@ export class TransportClient implements Client {
     return res.value;
   }
 
-  async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
+  async getInt(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -66,7 +66,7 @@ export class TransportClient implements Client {
     return res.value;
   }
 
-  async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
+  async getFloat(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -81,7 +81,7 @@ export class TransportClient implements Client {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
+  async getJSON(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -101,7 +101,7 @@ export class TransportClient implements Client {
     return {};
   }
 
-  async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
+  async getProto(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
     if (!ctx) {
       ctx = new ClientContext();
     }
@@ -123,7 +123,7 @@ export class TransportClient implements Client {
     });
   }
 
-  async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
+  async getString(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
     if (!ctx) {
       ctx = new ClientContext();
     }

--- a/src/evaluation/rule.ts
+++ b/src/evaluation/rule.ts
@@ -72,10 +72,10 @@ export default function evaluateRule(rule: Rule | undefined, namespace: string, 
     throw new Error('unknown rule type');
 }
 
-// If the hashed feature value % 100 <= threshold, it fits in the "bucket".
+// If the hashed config value % 100 <= threshold, it fits in the "bucket".
 // In reality, we internally store the threshold as an integer in [0,100000]
 // to account for up to 3 decimal places.
-// The feature value is salted using the namespace, feature name, and context key.
+// The config value is salted using the namespace, config name, and context key.
 function evaluateBucket(bucketF: CallExpression_Bucket, namespace: string, configName: string, context?: ClientContext) : boolean {
     const ctxKey = bucketF.contextKey;
     const value = context && context.get(ctxKey);

--- a/src/memory/__tests__/backend.test.ts
+++ b/src/memory/__tests__/backend.test.ts
@@ -67,15 +67,15 @@ test('test backend', async () => {
     expect(registerCalls[0].length).toEqual(1);
     expect(registerCalls[0][0].sidecarVersion).toEqual(defaultVersion);
 
-    expect(await backend.getBoolFeature('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
-    expect(await backend.getIntFeature('ns-1', 'int', new ClientContext().setInt('key', 12))).toEqual(BigInt(12));
-    expect(await backend.getFloatFeature('ns-1', 'float', new ClientContext().setDouble('key', 12.12))).toEqual(12.28);
-    expect(await backend.getStringFeature('ns-1', 'string', new ClientContext().setString('key', 'foo'))).toEqual('hello');
-    expect(await backend.getJSONFeature('ns-1', 'json', new ClientContext())).toEqual({a: 1});
-    expect(await backend.getProtoFeature('ns-1', 'proto', new ClientContext())).toEqual(protoAny());
+    expect(await backend.getBool('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
+    expect(await backend.getInt('ns-1', 'int', new ClientContext().setInt('key', 12))).toEqual(BigInt(12));
+    expect(await backend.getFloat('ns-1', 'float', new ClientContext().setDouble('key', 12.12))).toEqual(12.28);
+    expect(await backend.getString('ns-1', 'string', new ClientContext().setString('key', 'foo'))).toEqual('hello');
+    expect(await backend.getJSON('ns-1', 'json', new ClientContext())).toEqual({a: 1});
+    expect(await backend.getProto('ns-1', 'proto', new ClientContext())).toEqual(protoAny());
 
     expect(async () => {
-        await backend.getBoolFeature('ns-1', 'int', new ClientContext()); // type mismatch
+        await backend.getBool('ns-1', 'int', new ClientContext()); // type mismatch
     }).rejects.toThrow();
 
     const listResp = backend.store.listContents();
@@ -129,7 +129,7 @@ test('send metrics error', async () => {
     });
 
     await backend.initialize();
-    expect(await backend.getBoolFeature('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
+    expect(await backend.getBool('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
     await backend.close();
 
     expect(mockSendEvents.mock.calls.length).toEqual(1);
@@ -148,8 +148,8 @@ test('send metrics batch size', async () => {
     });
 
     await backend.initialize();
-    expect(await backend.getBoolFeature('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
-    expect(await backend.getBoolFeature('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
+    expect(await backend.getBool('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
+    expect(await backend.getBool('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
     await backend.close();
     expect(mockSendEvents.mock.calls.length).toEqual(2);
     expect(backend.eventsBatcher.batch.length).toEqual(0);
@@ -167,7 +167,7 @@ test('test json return type', async () => {
 
     await backend.initialize();
 
-    const result: jsonConfigType = await backend.getJSONFeature('ns-1', 'json', new ClientContext());
+    const result: jsonConfigType = await backend.getJSON('ns-1', 'json', new ClientContext());
     expect(result).toEqual({a: 1});
 
     await backend.close();
@@ -185,7 +185,7 @@ test('test empty context', async () => {
 
     await backend.initialize();
 
-    const result = await backend.getBoolFeature('ns-1', 'bool');
+    const result = await backend.getBool('ns-1', 'bool');
     expect(result).toEqual(true);
 
     await backend.close();

--- a/src/memory/__tests__/git.test.ts
+++ b/src/memory/__tests__/git.test.ts
@@ -84,12 +84,12 @@ test('test git', async () => {
     const { client, sha } = await setupClient();
     await client.initialize();
     expect(client.store.getCommitSHA()).toEqual(sha);
-    expect(await client.getBoolFeature('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
-    expect(await client.getIntFeature('ns-1', 'int', new ClientContext().setInt('key', 12))).toEqual(BigInt(12));
-    expect(await client.getFloatFeature('ns-1', 'float', new ClientContext().setDouble('key', 12.12))).toEqual(12.28);
-    expect(await client.getStringFeature('ns-1', 'string', new ClientContext().setString('key', 'foo'))).toEqual('hello');
-    expect(await client.getJSONFeature('ns-1', 'json', new ClientContext())).toEqual({a: 1});
-    expect(proto3.util.equals(Any, await client.getProtoFeature('ns-1', 'proto', new ClientContext()), protoAny())).toBeTruthy();
+    expect(await client.getBool('ns-1', 'bool', new ClientContext().setBoolean('key', true))).toEqual(true);
+    expect(await client.getInt('ns-1', 'int', new ClientContext().setInt('key', 12))).toEqual(BigInt(12));
+    expect(await client.getFloat('ns-1', 'float', new ClientContext().setDouble('key', 12.12))).toEqual(12.28);
+    expect(await client.getString('ns-1', 'string', new ClientContext().setString('key', 'foo'))).toEqual('hello');
+    expect(await client.getJSON('ns-1', 'json', new ClientContext())).toEqual({a: 1});
+    expect(proto3.util.equals(Any, await client.getProto('ns-1', 'proto', new ClientContext()), protoAny())).toBeTruthy();
     await client.close();
 });
 

--- a/src/memory/backend.ts
+++ b/src/memory/backend.ts
@@ -48,33 +48,33 @@ export class Backend implements Client {
         this.server = new SDKServer(this.store, port);
     }
 
-    async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
+    async getBool(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
         const wrapper = new BoolValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
+    async getInt(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
         const wrapper = new Int64Value();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
+    async getFloat(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
         const wrapper = new DoubleValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
+    async getString(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
         const wrapper = new StringValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
+    async getJSON(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
         const wrapper = new Value();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return JSON.parse(wrapper.toJsonString());
     }
-    async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
+    async getProto(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
         const result = this.store.evaluateType(namespace, key, ctx);
         this.track(namespace, key, result, ctx);
         return result.evalResult.value;

--- a/src/memory/git.ts
+++ b/src/memory/git.ts
@@ -86,33 +86,33 @@ export class Git implements Client {
         }
     }
 
-    async getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
+    async getBool(namespace: string, key: string, ctx?: ClientContext): Promise<boolean> {
         const wrapper = new BoolValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
+    async getInt(namespace: string, key: string, ctx?: ClientContext): Promise<bigint> {
         const wrapper = new Int64Value();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
+    async getFloat(namespace: string, key: string, ctx?: ClientContext): Promise<number> {
         const wrapper = new DoubleValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
-    async getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
+    async getString(namespace: string, key: string, ctx?: ClientContext): Promise<string> {
         const wrapper = new StringValue();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return wrapper.value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
+    async getJSON(namespace: string, key: string, ctx?: ClientContext): Promise<any> {
         const wrapper = new Value();
         await this.evaluateAndUnpack(namespace, key, wrapper, ctx);
         return JSON.parse(wrapper.toJsonString());
     }
-    async getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
+    async getProto(namespace: string, key: string, ctx?: ClientContext): Promise<Any> {
         const result = this.store.evaluateType(namespace, key, ctx);
         this.track(namespace, key, result, ctx);
         return result.evalResult.value;

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -2,13 +2,13 @@ import { Any } from "@bufbuild/protobuf";
 import { ClientContext } from "../context/context";
 
 export interface Client {
-    getBoolFeature(namespace: string, key: string, ctx?: ClientContext): Promise<boolean>;
-    getIntFeature(namespace: string, key: string, ctx?: ClientContext): Promise<bigint>;
-    getFloatFeature(namespace: string, key: string, ctx?: ClientContext): Promise<number>;
-    getStringFeature(namespace: string, key: string, ctx?: ClientContext): Promise<string>
+    getBool(namespace: string, key: string, ctx?: ClientContext): Promise<boolean>;
+    getInt(namespace: string, key: string, ctx?: ClientContext): Promise<bigint>;
+    getFloat(namespace: string, key: string, ctx?: ClientContext): Promise<number>;
+    getString(namespace: string, key: string, ctx?: ClientContext): Promise<string>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getJSONFeature(namespace: string, key: string, ctx?: ClientContext): Promise<any>;
-    getProtoFeature(namespace: string, key: string, ctx?: ClientContext): Promise<Any>;
+    getJSON(namespace: string, key: string, ctx?: ClientContext): Promise<any>;
+    getProto(namespace: string, key: string, ctx?: ClientContext): Promise<Any>;
     close(): Promise<void>;
 }
 


### PR DESCRIPTION
- Update client interface methods to more closely match the go-sdk, removing use of `Feature`

This is a breaking change.