### PR TITLE
create context from json

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -41,7 +41,7 @@ class ClientContext {
     return this;
   }
 
-  static fromJson(jsonContext?: {
+  static fromJSON(jsonContext?: {
     [key: string]: string | number | boolean;
   }): ClientContext {
     const ctx = new ClientContext();

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,5 +1,4 @@
-import { Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';
-import { JsonObject } from "@bufbuild/protobuf";
+import { Value } from "@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb";
 
 type ContextKey = string;
 
@@ -42,12 +41,14 @@ class ClientContext {
     return this;
   }
 
-  static fromJson(jsonObject?: JsonObject): ClientContext {
+  static fromJson(jsonContext?: {
+    [key: string]: string | number | boolean;
+  }): ClientContext {
     const ctx = new ClientContext();
-    if (jsonObject === undefined) {
+    if (jsonContext === undefined) {
       return ctx;
     }
-    Object.entries(jsonObject).forEach(([k, v]) => {
+    Object.entries(jsonContext).forEach(([k, v]) => {
       switch (typeof v) {
         case "number":
           // TODO: `1.0` is still integer in js :(

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,4 +1,5 @@
 import { Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';
+import { JsonObject } from "@bufbuild/protobuf";
 
 type ContextKey = string;
 
@@ -41,12 +42,38 @@ class ClientContext {
     return this;
   }
 
+  static fromJson(jsonObject?: JsonObject): ClientContext {
+    const ctx = new ClientContext();
+    if (jsonObject === undefined) {
+      return ctx;
+    }
+    Object.entries(jsonObject).forEach(([k, v]) => {
+      switch (typeof v) {
+        case "number":
+          // TODO: `1.0` is still integer in js :(
+          if (Number.isInteger(v)) {
+            ctx.setInt(k, v);
+          } else {
+            ctx.setDouble(k, v);
+          }
+          break;
+        case "string":
+          ctx.setString(k, v);
+          break;
+        case "boolean":
+          ctx.setBoolean(k, v);
+          break;
+      }
+    });
+    return ctx;
+  }
+
   toString(): string {
     const pairs: string[] = [];
     for (const k in this.data) {
       pairs.push(`${k}: ${this.data[k].kind.value}`);
     }
-    return pairs.join(', ');
+    return pairs.join(", ");
   }
 }
 


### PR DESCRIPTION
to avoid forcing people to use `ClientContext` directly

```
{
  env: "prod",
}
```
is much more natural than
```
new lekko.ClientContext().setString("env", "prod")
```