### PR TITLE
Implement ConfigurationService server for local dev support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_STORE
 node_modules
 /lib
+/bin
 /coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/js-yaml": "^4.0.5",
         "browser-or-node": "^2.1.1",
         "commander": "^12.0.0",
+        "cors": "^2.8.5",
         "esbuild": "^0.17.17",
         "exponential-backoff": "^3.1.1",
         "isomorphic-git": "^1.24.5",
@@ -29,9 +30,10 @@
         "unionfs": "^4.5.1"
       },
       "bin": {
-        "server": "bin/server.js"
+        "lekko-server": "bin/server.js"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/jest": "^29.4.0",
         "@types/node": "^18.13.0",
         "@types/xxhashjs": "^0.2.2",
@@ -1808,6 +1810,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -2684,6 +2695,18 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -5457,6 +5480,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -6802,6 +6833,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lekko/node-server-sdk",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lekko/node-server-sdk",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@buf/lekkodev_cli.bufbuild_connect-es": "^0.12.0-20230725173132-dd46c8444719.1",
         "@buf/lekkodev_cli.bufbuild_es": "^1.3.0-20230725173132-dd46c8444719.1",
@@ -18,6 +18,7 @@
         "@bufbuild/protobuf": "^1.2.0",
         "@types/js-yaml": "^4.0.5",
         "browser-or-node": "^2.1.1",
+        "commander": "^12.0.0",
         "esbuild": "^0.17.17",
         "exponential-backoff": "^3.1.1",
         "isomorphic-git": "^1.24.5",
@@ -26,6 +27,9 @@
         "node-watch": "^0.7.4",
         "set-interval-async": "^3.0.3",
         "unionfs": "^4.5.1"
+      },
+      "bin": {
+        "server": "bin/server.js"
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",
@@ -2662,12 +2666,11 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -3774,6 +3777,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/genversion/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ts"
   ],
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.13.0",
     "@types/xxhashjs": "^0.2.2",
@@ -65,6 +66,7 @@
     "@types/js-yaml": "^4.0.5",
     "browser-or-node": "^2.1.1",
     "commander": "^12.0.0",
+    "cors": "^2.8.5",
     "esbuild": "^0.17.17",
     "exponential-backoff": "^3.1.1",
     "isomorphic-git": "^1.24.5",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "description": "Lekko Node Server SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": {
+    "lekko-server": "bin/server.js"
+  },
   "scripts": {
-    "build": "genversion -use src/version.js && tsc && esbuild src/index.ts --platform=node --bundle --outdir=lib/ --global-name=lekko",
+    "build": "genversion -use src/version.js && tsc && esbuild src/index.ts --platform=node --bundle --outdir=lib/ --global-name=lekko && esbuild src/server.ts --platform=node --bundle --outfile=bin/server.js",
     "lint": "eslint . --ext .ts",
     "test": "jest --config jestconfig.json",
     "prepare": "npm run build",
@@ -61,6 +64,7 @@
     "@bufbuild/protobuf": "^1.2.0",
     "@types/js-yaml": "^4.0.5",
     "browser-or-node": "^2.1.1",
+    "commander": "^12.0.0",
     "esbuild": "^0.17.17",
     "exponential-backoff": "^3.1.1",
     "isomorphic-git": "^1.24.5",

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,12 +1,15 @@
-import { Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';
+import { Value } from "@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb";
 
 type ContextKey = string;
 
 class ClientContext {
   data: { [key: ContextKey]: Value };
 
-  constructor() {
+  constructor(data?: { [key: ContextKey]: Value }) {
     this.data = {};
+    if (data !== undefined) {
+      this.data = data;
+    }
   }
 
   get(key: string): Value | undefined {
@@ -46,7 +49,7 @@ class ClientContext {
     for (const k in this.data) {
       pairs.push(`${k}: ${this.data[k].kind.value}`);
     }
-    return pairs.join(', ');
+    return pairs.join(", ");
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,8 @@ type APIOptions = {
   transportProtocol?: TransportProtocol
 }
 
-async function initAPIClient(options: APIOptions): Promise<AsyncClient> {
-  const transport = await new ClientTransportBuilder(
+function initAPIClient(options: APIOptions): AsyncClient {
+  const transport = new ClientTransportBuilder(
     {
       hostname: options.hostname ?? "https://prod.api.lekko.dev",
       protocol: options.transportProtocol ?? TransportProtocol.HTTP,
@@ -34,8 +34,8 @@ type SidecarOptions = {
   transportProtocol?: TransportProtocol
 }
 
-async function initSidecarClient(options: SidecarOptions): Promise<AsyncClient> {
-  const transport = await new ClientTransportBuilder(
+function initSidecarClient(options: SidecarOptions): AsyncClient {
+  const transport = new ClientTransportBuilder(
     {
       hostname: options.hostname ?? "http://localhost:50051",
       protocol: options.transportProtocol ?? TransportProtocol.gRPC,
@@ -56,7 +56,7 @@ type BackendOptions = {
 const defaultUpdateIntervalMs = 15 * 1000; // 15s
 
 async function initCachedAPIClient(options: BackendOptions): Promise<Client> {
-  const transport = await new ClientTransportBuilder({
+  const transport = new ClientTransportBuilder({
     hostname: options.hostname ?? "https://prod.api.lekko.dev",
     protocol: options.transportProtocol ?? TransportProtocol.HTTP,
     apiKey: options.apiKey
@@ -90,7 +90,7 @@ type GitOptions = {
 async function initCachedGitClient(options: GitOptions): Promise<Client> {
   let transport: Transport | undefined;
   if (options.apiKey) {
-    transport = await new ClientTransportBuilder({
+    transport = new ClientTransportBuilder({
       hostname: options.hostname ?? "https://prod.api.lekko.dev",
       protocol: options.transportProtocol ?? TransportProtocol.HTTP,
       apiKey: options.apiKey
@@ -121,7 +121,7 @@ type LocalOptions = {
  */
 async function initClient(options?: LocalOptions | BackendOptions): Promise<Client> {
   if (options !== undefined && "apiKey" in options) {
-    const transport = await new ClientTransportBuilder({
+    const transport = new ClientTransportBuilder({
       hostname: options.hostname ?? "https://prod.api.lekko.dev",
       protocol: options.transportProtocol ?? TransportProtocol.HTTP,
       apiKey: options.apiKey
@@ -138,9 +138,9 @@ async function initClient(options?: LocalOptions | BackendOptions): Promise<Clie
     return client;
   } else {
     let path = "";
-    if (options !== undefined && "path" in options) {
+    if (options !== undefined && "path" in options && options.path !== undefined) {
       path = options.path;
-    } else if (options === undefined || !("path" in options)) {
+    } else {
       // Invoke Lekko CLI to ensure default path location presence
       const defaultInit = spawnSync("lekko", ["repo", "init-default"], { encoding: "utf-8" });
       if (defaultInit.error !== undefined || defaultInit.status !== 0) {

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -2,7 +2,6 @@ import { SDKService } from "@buf/lekkodev_sdk.bufbuild_connect-es/lekko/server/v
 import { ConfigurationService } from '@buf/lekkodev_sdk.bufbuild_connect-es/lekko/client/v1beta1/configuration_service_connect';
 import { Code, ConnectError, ConnectRouter } from "@bufbuild/connect";
 import { connectNodeAdapter } from "@bufbuild/connect-node";
-// import { Http2Server, createServer } from 'http2';
 import { NotFoundError } from "./store";
 import * as http from "http";
 import { GetBoolValueResponse, GetFloatValueResponse, GetIntValueResponse, GetJSONValueResponse, GetProtoValueResponse, GetStringValueResponse, Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -1,26 +1,155 @@
 import { SDKService } from "@buf/lekkodev_sdk.bufbuild_connect-es/lekko/server/v1beta1/sdk_connect";
-import { ConnectRouter } from "@bufbuild/connect";
+import { ConfigurationService } from '@buf/lekkodev_sdk.bufbuild_connect-es/lekko/client/v1beta1/configuration_service_connect';
+import { Code, ConnectError, ConnectRouter } from "@bufbuild/connect";
 import { connectNodeAdapter } from "@bufbuild/connect-node";
-import { Http2Server, createServer } from 'http2';
-import { Store } from "./store";
+// import { Http2Server, createServer } from 'http2';
+import { NotFoundError } from "./store";
+import * as http from "http";
+import { GetBoolValueResponse, GetFloatValueResponse, GetIntValueResponse, GetJSONValueResponse, GetProtoValueResponse, GetStringValueResponse, Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';
+import { Client, DevClient } from '../types/client';
+import { ClientContext } from '../context/context';
+
+const LOCAL_PATH_HEADER = "localpath";
 
 // Runs a simple vanilla nodejs web server for debugging. 
 // The server exposes the interface defined here: 
 //      https://buf.build/lekkodev/sdk/docs/main:lekko.server.v1beta1
 export class SDKServer {
-    server?: Http2Server;
+    client: Client & DevClient;
+    server?: http.Server;
 
-    constructor(store: Store, port?: number) {
+    constructor(client: Client & DevClient, port?: number) {
+        this.client = client;
         if (!port) {
             return;
         }
-        const routes = (router: ConnectRouter) => 
+        const routes = (router: ConnectRouter) => {
             router.service(SDKService, {
-                async listContents() {
-                    return store.listContents();
+                listContents: async () => {
+                    return this.client.listContents();
                 }
             });
-        this.server = createServer(connectNodeAdapter({ routes })).listen(port);
+            // TODO: Clean up code once interceptor support lands in connect-node
+            router.service(ConfigurationService, {
+                getBoolValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        await this.handleHeaders(context.requestHeader);
+                        const value = this.client.getBool(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("boolean", req.namespace, req.key);
+                        return new GetBoolValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                },
+                getIntValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        const value = this.client.getInt(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("int", req.namespace, req.key);
+                        return new GetIntValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                },
+                getFloatValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        const value = this.client.getFloat(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("float", req.namespace, req.key);
+                        return new GetFloatValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                },
+                getStringValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        const value = this.client.getString(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("string", req.namespace, req.key);
+                        return new GetStringValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                },
+                getJSONValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        const value = this.client.getJSON(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("JSON", req.namespace, req.key);
+                        return new GetJSONValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                },
+                getProtoValue: async (req, context) => {
+                    await this.handleHeaders(context.requestHeader);
+                    try {
+                        const value = this.client.getProto(req.namespace, req.key, this.fromReqContext(req.context));
+                        this.logEval("proto", req.namespace, req.key);
+                        return new GetProtoValueResponse({ value });
+                    } catch (e) {
+                        if (e instanceof NotFoundError) {
+                            throw new ConnectError(e.message, Code.NotFound);
+                        }
+                        throw e;
+                    }
+                }
+            });
+        };
+        this.server = http.createServer(connectNodeAdapter({ routes })).listen(port);
+    }
+
+    fromReqContext(context: { [key: string]: Value }): ClientContext {
+        const clientContext = new ClientContext();
+        Object.entries(context).forEach(([key, value]) => {
+            switch (value.kind.case) {
+                case "boolValue": {
+                    clientContext.setBoolean(key, value.kind.value);
+                    break;
+                }
+                case "intValue": {
+                    // TODO: SDKs should correctly handle near-64-bit cases
+                    clientContext.setInt(key, Number(value.kind.value));
+                    break;
+                }
+                case "doubleValue": {
+                    clientContext.setDouble(key, value.kind.value);
+                    break;
+                }
+                case "stringValue": {
+                    clientContext.setString(key, value.kind.value);
+                }
+            }
+        });
+        return clientContext;
+    }
+
+    logEval(type: string, namespace: string, key: string): void {
+        // eslint-disable-next-line no-console
+        console.log(`Evaluated ${type} config ${namespace}/${key}`);
+    }
+
+    async handleHeaders(headers: Headers): Promise<void> {
+        const localPath = headers.get(LOCAL_PATH_HEADER);
+        if (localPath) {
+            await this.client.reinitialize({ path: localPath });
+        }
     }
 
     close() {
@@ -28,7 +157,7 @@ export class SDKServer {
             this.server.close((err) => {
                 if (err) {
                     // eslint-disable-next-line no-console
-                    console.error('Error closing sdk server', err);
+                    console.error('Error closing SDK server', err);
                 }
             });
         }

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -53,7 +53,6 @@ export class SDKServer {
         getBoolValue: async (req, context) => {
           await this.handleHeaders(context.requestHeader);
           try {
-            await this.handleHeaders(context.requestHeader);
             const value = this.client.getBool(
               req.namespace,
               req.key,

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -1,164 +1,214 @@
 import { SDKService } from "@buf/lekkodev_sdk.bufbuild_connect-es/lekko/server/v1beta1/sdk_connect";
-import { ConfigurationService } from '@buf/lekkodev_sdk.bufbuild_connect-es/lekko/client/v1beta1/configuration_service_connect';
+import { ConfigurationService } from "@buf/lekkodev_sdk.bufbuild_connect-es/lekko/client/v1beta1/configuration_service_connect";
 import { Code, ConnectError, ConnectRouter } from "@bufbuild/connect";
 import { connectNodeAdapter } from "@bufbuild/connect-node";
+import { cors as connectCors } from "@bufbuild/connect";
+import cors from "cors";
 import { NotFoundError } from "./store";
-import * as http from "http";
-import { GetBoolValueResponse, GetFloatValueResponse, GetIntValueResponse, GetJSONValueResponse, GetProtoValueResponse, GetStringValueResponse, Value } from '@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb';
-import { Client, DevClient } from '../types/client';
-import { ClientContext } from '../context/context';
+import http from "http";
+import {
+  GetBoolValueResponse,
+  GetFloatValueResponse,
+  GetIntValueResponse,
+  GetJSONValueResponse,
+  GetProtoValueResponse,
+  GetStringValueResponse,
+  Value,
+} from "@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb";
+import { Client, DevClient } from "../types/client";
+import { ClientContext } from "../context/context";
 
 const LOCAL_PATH_HEADER = "localpath";
 
-// Runs a simple vanilla nodejs web server for debugging. 
-// The server exposes the interface defined here: 
+// Runs a simple vanilla nodejs web server for debugging.
+// The server exposes the interface defined here:
 //      https://buf.build/lekkodev/sdk/docs/main:lekko.server.v1beta1
 export class SDKServer {
-    client: Client & DevClient;
-    server?: http.Server;
+  client: Client & DevClient;
+  server?: http.Server;
 
-    constructor(client: Client & DevClient, port?: number) {
-        this.client = client;
-        if (!port) {
-            return;
-        }
-        const routes = (router: ConnectRouter) => {
-            router.service(SDKService, {
-                listContents: async () => {
-                    return this.client.listContents();
-                }
-            });
-            // TODO: Clean up code once interceptor support lands in connect-node
-            router.service(ConfigurationService, {
-                getBoolValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        await this.handleHeaders(context.requestHeader);
-                        const value = this.client.getBool(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("boolean", req.namespace, req.key);
-                        return new GetBoolValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                },
-                getIntValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        const value = this.client.getInt(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("int", req.namespace, req.key);
-                        return new GetIntValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                },
-                getFloatValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        const value = this.client.getFloat(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("float", req.namespace, req.key);
-                        return new GetFloatValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                },
-                getStringValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        const value = this.client.getString(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("string", req.namespace, req.key);
-                        return new GetStringValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                },
-                getJSONValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        const value = this.client.getJSON(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("JSON", req.namespace, req.key);
-                        return new GetJSONValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                },
-                getProtoValue: async (req, context) => {
-                    await this.handleHeaders(context.requestHeader);
-                    try {
-                        const value = this.client.getProto(req.namespace, req.key, this.fromReqContext(req.context));
-                        this.logEval("proto", req.namespace, req.key);
-                        return new GetProtoValueResponse({ value });
-                    } catch (e) {
-                        if (e instanceof NotFoundError) {
-                            throw new ConnectError(e.message, Code.NotFound);
-                        }
-                        throw e;
-                    }
-                }
-            });
-        };
-        this.server = http.createServer(connectNodeAdapter({ routes })).listen(port);
+  constructor(client: Client & DevClient, port?: number) {
+    this.client = client;
+    if (!port) {
+      return;
     }
-
-    fromReqContext(context: { [key: string]: Value }): ClientContext {
-        const clientContext = new ClientContext();
-        Object.entries(context).forEach(([key, value]) => {
-            switch (value.kind.case) {
-                case "boolValue": {
-                    clientContext.setBoolean(key, value.kind.value);
-                    break;
-                }
-                case "intValue": {
-                    // TODO: SDKs should correctly handle near-64-bit cases
-                    clientContext.setInt(key, Number(value.kind.value));
-                    break;
-                }
-                case "doubleValue": {
-                    clientContext.setDouble(key, value.kind.value);
-                    break;
-                }
-                case "stringValue": {
-                    clientContext.setString(key, value.kind.value);
-                }
+    const corsHandler = cors({
+      origin: true,
+      methods: [...connectCors.allowedMethods],
+      allowedHeaders: [
+        LOCAL_PATH_HEADER,
+        "apikey",
+        ...connectCors.allowedHeaders,
+      ],
+      exposedHeaders: [...connectCors.exposedHeaders],
+    });
+    const routes = (router: ConnectRouter) => {
+      router.service(SDKService, {
+        listContents: async () => {
+          return this.client.listContents();
+        },
+      });
+      // TODO: Clean up code once interceptor support lands in connect-node
+      router.service(ConfigurationService, {
+        getBoolValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            await this.handleHeaders(context.requestHeader);
+            const value = this.client.getBool(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("boolean", req.namespace, req.key);
+            return new GetBoolValueResponse({ value });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
             }
-        });
-        return clientContext;
-    }
-
-    logEval(type: string, namespace: string, key: string): void {
-        // eslint-disable-next-line no-console
-        console.log(`Evaluated ${type} config ${namespace}/${key}`);
-    }
-
-    async handleHeaders(headers: Headers): Promise<void> {
-        const localPath = headers.get(LOCAL_PATH_HEADER);
-        if (localPath) {
-            await this.client.reinitialize({ path: localPath });
-        }
-    }
-
-    close() {
-        if (this.server) {
-            this.server.close((err) => {
-                if (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('Error closing SDK server', err);
-                }
+            throw e;
+          }
+        },
+        getIntValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            const value = this.client.getInt(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("int", req.namespace, req.key);
+            return new GetIntValueResponse({ value });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
+            }
+            throw e;
+          }
+        },
+        getFloatValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            const value = this.client.getFloat(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("float", req.namespace, req.key);
+            return new GetFloatValueResponse({ value });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
+            }
+            throw e;
+          }
+        },
+        getStringValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            const value = this.client.getString(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("string", req.namespace, req.key);
+            return new GetStringValueResponse({ value });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
+            }
+            throw e;
+          }
+        },
+        getJSONValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            const value = this.client.getJSON(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("JSON", req.namespace, req.key);
+            return new GetJSONValueResponse({
+              value: new TextEncoder().encode(JSON.stringify(value)),
             });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
+            }
+            throw e;
+          }
+        },
+        getProtoValue: async (req, context) => {
+          await this.handleHeaders(context.requestHeader);
+          try {
+            const value = this.client.getProto(
+              req.namespace,
+              req.key,
+              this.fromReqContext(req.context)
+            );
+            this.logEval("proto", req.namespace, req.key);
+            return new GetProtoValueResponse({ value });
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new ConnectError(e.message, Code.NotFound);
+            }
+            throw e;
+          }
+        },
+      });
+    };
+    this.server = http
+      .createServer((req, res) =>
+        corsHandler(req, res, () => connectNodeAdapter({ routes })(req, res))
+      )
+      .listen(port);
+  }
+
+  fromReqContext(context: { [key: string]: Value }): ClientContext {
+    const clientContext = new ClientContext();
+    Object.entries(context).forEach(([key, value]) => {
+      switch (value.kind.case) {
+        case "boolValue": {
+          clientContext.setBoolean(key, value.kind.value);
+          break;
         }
+        case "intValue": {
+          // TODO: SDKs should correctly handle near-64-bit cases
+          clientContext.setInt(key, Number(value.kind.value));
+          break;
+        }
+        case "doubleValue": {
+          clientContext.setDouble(key, value.kind.value);
+          break;
+        }
+        case "stringValue": {
+          clientContext.setString(key, value.kind.value);
+        }
+      }
+    });
+    return clientContext;
+  }
+
+  logEval(type: string, namespace: string, key: string): void {
+    // eslint-disable-next-line no-console
+    console.log(`Served ${type} config ${namespace}/${key}`);
+  }
+
+  async handleHeaders(headers: Headers): Promise<void> {
+    const localPath = headers.get(LOCAL_PATH_HEADER);
+    if (localPath) {
+      await this.client.reinitialize({ path: localPath });
     }
+  }
+
+  close() {
+    if (this.server) {
+      this.server.close((err) => {
+        if (err) {
+          // eslint-disable-next-line no-console
+          console.error("Error closing SDK server", err);
+        }
+      });
+    }
+  }
 }

--- a/src/memory/server.ts
+++ b/src/memory/server.ts
@@ -13,7 +13,6 @@ import {
   GetJSONValueResponse,
   GetProtoValueResponse,
   GetStringValueResponse,
-  Value,
 } from "@buf/lekkodev_sdk.bufbuild_es/lekko/client/v1beta1/configuration_service_pb";
 import { Client, DevClient } from "../types/client";
 import { ClientContext } from "../context/context";
@@ -56,7 +55,7 @@ export class SDKServer {
             const value = this.client.getBool(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("boolean", req.namespace, req.key);
             return new GetBoolValueResponse({ value });
@@ -73,7 +72,7 @@ export class SDKServer {
             const value = this.client.getInt(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("int", req.namespace, req.key);
             return new GetIntValueResponse({ value });
@@ -90,7 +89,7 @@ export class SDKServer {
             const value = this.client.getFloat(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("float", req.namespace, req.key);
             return new GetFloatValueResponse({ value });
@@ -107,7 +106,7 @@ export class SDKServer {
             const value = this.client.getString(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("string", req.namespace, req.key);
             return new GetStringValueResponse({ value });
@@ -124,7 +123,7 @@ export class SDKServer {
             const value = this.client.getJSON(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("JSON", req.namespace, req.key);
             return new GetJSONValueResponse({
@@ -143,7 +142,7 @@ export class SDKServer {
             const value = this.client.getProto(
               req.namespace,
               req.key,
-              this.fromReqContext(req.context)
+              new ClientContext(req.context)
             );
             this.logEval("proto", req.namespace, req.key);
             return new GetProtoValueResponse({ value });
@@ -161,31 +160,6 @@ export class SDKServer {
         corsHandler(req, res, () => connectNodeAdapter({ routes })(req, res))
       )
       .listen(port);
-  }
-
-  fromReqContext(context: { [key: string]: Value }): ClientContext {
-    const clientContext = new ClientContext();
-    Object.entries(context).forEach(([key, value]) => {
-      switch (value.kind.case) {
-        case "boolValue": {
-          clientContext.setBoolean(key, value.kind.value);
-          break;
-        }
-        case "intValue": {
-          // TODO: SDKs should correctly handle near-64-bit cases
-          clientContext.setInt(key, Number(value.kind.value));
-          break;
-        }
-        case "doubleValue": {
-          clientContext.setDouble(key, value.kind.value);
-          break;
-        }
-        case "stringValue": {
-          clientContext.setString(key, value.kind.value);
-        }
-      }
-    });
-    return clientContext;
   }
 
   logEval(type: string, namespace: string, key: string): void {

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -13,6 +13,12 @@ type configData = {
 
 type configMap = Map<string, Map<string, configData>>
 
+export class NotFoundError extends Error {
+    constructor(resType: "namespace" | "config", name: string) {
+        super(`${resType} ${name} not found`);
+    }
+}
+
 export type StoredEvalResult = {
     config: Feature,
     configSHA: string,
@@ -38,11 +44,11 @@ export class Store {
     get(namespace: string, configKey: string) {
         const nsMap = this.configs.get(namespace);
         if (!nsMap) {
-            throw new Error('namespace not found');
+            throw new NotFoundError("namespace", namespace);
         }
         const result = nsMap.get(configKey);
         if (!result) {
-            throw new Error('config not found');
+            throw new NotFoundError("config", configKey);
         }
         return result;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { program, InvalidArgumentError } from "commander";
+import { initClient } from ".";
+
+function parsePort(value: string): number {
+  const port = parseInt(value, 10);
+  if (isNaN(port)) {
+    throw new InvalidArgumentError("Invalid port");
+  }
+  return port;
+}
+
+program
+  .option(
+    "-p, --port <number>",
+    "port to start config dev server on",
+    parsePort,
+    50051
+  )
+  .option("-r, --repo-path <string>", "path to config repo");
+program.parse();
+
+const opts = program.opts();
+const port = parseInt(opts.port);
+
+initClient({
+  path: opts.repoPath,
+  serverPort: port,
+}).then(() =>
+  // eslint-disable-next-line no-console
+  console.log(`Started Lekko config dev server on localhost:${port}`)
+);

--- a/src/transport-builder.ts
+++ b/src/transport-builder.ts
@@ -1,4 +1,4 @@
-import { type Transport } from "@bufbuild/connect";
+import { Interceptor, type Transport } from "@bufbuild/connect";
 import { createGrpcWebTransport, createConnectTransport, createGrpcTransport } from "@bufbuild/connect-node";
 
 export enum TransportProtocol {
@@ -7,7 +7,7 @@ export enum TransportProtocol {
   gRPCWeb
 }
 
-const APIKEY_INTERCEPTOR = (apiKey?: string) => (next: any) => async (req: any) => {
+const APIKEY_INTERCEPTOR: (apiKey?: string) => Interceptor = (apiKey?: string) => (next) => async (req) => {
   if (apiKey) {
     req.header.set('apikey', apiKey);
   }
@@ -25,7 +25,7 @@ export class ClientTransportBuilder {
     this.apiKey = apiKey;
   }
 
-  async build(): Promise<Transport> {
+  build(): Transport {
     if (this.protocol == TransportProtocol.HTTP) {
       if (this.apiKey === undefined) {
         throw new Error("API Key required");

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,5 +1,6 @@
 import { Any } from "@bufbuild/protobuf";
 import { ClientContext } from "../context/context";
+import { ListContentsResponse } from '@buf/lekkodev_sdk.bufbuild_es/lekko/server/v1beta1/sdk_pb';
 
 export interface AsyncClient {
     getBool(namespace: string, key: string, ctx?: ClientContext): Promise<boolean>;
@@ -21,4 +22,9 @@ export interface Client {
   getJSON(namespace: string, key: string, ctx?: ClientContext): any;
   getProto(namespace: string, key: string, ctx?: ClientContext): Any;
   close(): Promise<void>;
+}
+
+export interface DevClient {
+    listContents(): ListContentsResponse;
+    reinitialize(options: { path?: string }): Promise<void>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       // ES2018.AsyncIterable for AsyncIterator
       "ES2018.AsyncIterable"
     ],
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
# Details
- Updated SDKServer class to also implement ConfigurationService methods
    - Also handle reading specific headers from requests to allow reinitializing for different repo paths
- Updated remote-only client initialization to be non-async
- Added binary script `lekko-server` that starts a config server that can be connected to by other SDKs (tested with js-sdk)

Example usage
```
# In a project using this SDK...
npm install --save @lekko/node-server-sdk
# You can invoke server script via npx
npx lekko-server
# Or yarn if you use yarn
yarn lekko-server
# Can also pass some args
npx lekko-server --port 50051 --repo-path ~/path/to/repo
```